### PR TITLE
v0.4.0 Update signed expiration representation

### DIFF
--- a/dydx3/starkex/constants.py
+++ b/dydx3/starkex/constants.py
@@ -1,5 +1,8 @@
 """Constants related to creating hashes of Starkware objects."""
 
+ONE_HOUR_IN_SECONDS = 60 * 60
+ORDER_SIGNATURE_EXPIRATION_BUFFER_HOURS = 24 * 2  # Two days.
+
 CONDITIONAL_TRANSFER_PADDING_BITS = 81
 CONDITIONAL_TRANSFER_PREFIX = 5
 ORDER_PREFIX = 3
@@ -18,7 +21,7 @@ CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS = {
     "condition": 251,
     "quantums_amount": 64,
     "nonce": 32,
-    "expiration_epoch_seconds": 32,
+    "expiration_epoch_hours": 32,
 }
 
 ORDER_FIELD_BIT_LENGTHS = {
@@ -28,7 +31,7 @@ ORDER_FIELD_BIT_LENGTHS = {
     "quantums_amount": 64,
     "nonce": 32,
     "position_id": 64,
-    "expiration_epoch_seconds": 32,
+    "expiration_epoch_hours": 32,
 }
 
 WITHDRAWAL_FIELD_BIT_LENGTHS = {
@@ -36,7 +39,7 @@ WITHDRAWAL_FIELD_BIT_LENGTHS = {
     "position_id": 64,
     "nonce": 32,
     "quantums_amount": 64,
-    "expiration_epoch_seconds": 32,
+    "expiration_epoch_hours": 32,
 }
 
 ORACLE_PRICE_FIELD_BIT_LENGTHS = {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='0.3.0',
+    version='0.4.0',
     packages=find_packages(),
     package_data={
         'dydx3': [

--- a/tests/starkex/test_conditional_transfer.py
+++ b/tests/starkex/test_conditional_transfer.py
@@ -8,8 +8,8 @@ MOCK_PRIVATE_KEY = (
     '58c7d5a90b1776bde86ebac077e053ed85b0f7164f53b080304a531947f46e3'
 )
 MOCK_SIGNATURE = (
-    '014dedad7bd42da36e81ce627e55be508a4afe019700dd478ea8134b3549d327' +
-    '0571d1dcbab6f25f4d2f3af054f359773289266c69df91c9608882f0a9b201d8'
+    '067e90143a21d8a6aca85207de5e124e9644f7adc18deb42c5cf1240766e57bb' +
+    '04a39c4fdadf214d7282a59d37b21e0d3ea7fe1fc0d0ee25c22a3dd9d5cb8307'
 )
 
 # Mock conditional transfer params.
@@ -40,3 +40,11 @@ class TestConditionalTransfer():
     def test_verify_signature(self):
         transfer = SignableConditionalTransfer(**CONDITIONAL_TRANSFER_PARAMS)
         assert transfer.verify_signature(MOCK_SIGNATURE, MOCK_PUBLIC_KEY)
+
+    def test_starkware_representation(self):
+        transfer = SignableConditionalTransfer(**CONDITIONAL_TRANSFER_PARAMS)
+        starkware_transfer = transfer.to_starkware()
+        assert starkware_transfer.quantums_amount == 49478023
+
+        # Order expiration should be rounded up and should have a buffer added.
+        assert starkware_transfer.expiration_epoch_hours == 444533

--- a/tests/starkex/test_order.py
+++ b/tests/starkex/test_order.py
@@ -11,8 +11,8 @@ MOCK_PRIVATE_KEY = (
     '58c7d5a90b1776bde86ebac077e053ed85b0f7164f53b080304a531947f46e3'
 )
 MOCK_SIGNATURE = (
-    '059487ea7c537f34516f4dc7c54ad30ab0096823269ba18aea0e64e13fb03462' +
-    '03be73ed4dafbf99baeeaee6dce315cd834b5e3257d4e74371d14cf8f2189a59'
+    '0398287472161cba0e6386ff0b2f25f39ba37c646b7bbadace80eee6b8e7157d' +
+    '01ba924272e1e42b3211b96bbbe012e7e8101e1b3e5b83ea90d161ad11fcced4'
 )
 
 # Test data where the public key y-coordinate is even.
@@ -20,8 +20,8 @@ MOCK_PUBLIC_KEY_EVEN_Y = (
     '5c749cd4c44bdc730bc90af9bfbdede9deb2c1c96c05806ce1bc1cb4fed64f7'
 )
 MOCK_SIGNATURE_EVEN_Y = (
-    '030644ef5b2de9e93f13df5a4cf8284e7256223366b5da29bf2002ed40825171' +
-    '03961ec47c34c49e97095c546895cc22afa6e563474615729720fd8b768c5b87'
+    '05cf391a69386f53693344bada2e0d245879f3c6a98971498b2862ff2f359c49' +
+    '0737deea7e201eaa86c8d6eeb2c1ca3ce89ac248b3fe1a6182301aa72d6e8e4f'
 )
 
 # Mock order params.
@@ -60,12 +60,15 @@ class TestOrder():
             MOCK_PUBLIC_KEY_EVEN_Y,
         )
 
-    def test_starkware_amounts(self):
+    def test_starkware_representation(self):
         order = SignableOrder(**ORDER_PARAMS)
         starkware_order = order.to_starkware()
         assert starkware_order.quantums_amount_synthetic == 14500050000
         assert starkware_order.quantums_amount_collateral == 50750272151
         assert starkware_order.quantums_amount_fee == 6343784019
+
+        # Order expiration should be rounded up and should have a buffer added.
+        assert starkware_order.expiration_epoch_hours == 444581
 
     def test_convert_order_fee_edge_case(self):
         order = SignableOrder(

--- a/tests/starkex/test_withdrawal.py
+++ b/tests/starkex/test_withdrawal.py
@@ -8,8 +8,8 @@ MOCK_PRIVATE_KEY = (
     '58c7d5a90b1776bde86ebac077e053ed85b0f7164f53b080304a531947f46e3'
 )
 MOCK_SIGNATURE = (
-    '0214a0ab2f3c065c5848ad9dbac6cc98509b66e76a8f563d5c8ffda01b0fa2e0' +
-    '07242b1c65d039fe645d122ecea7c3e58c8fda5814e0c152dbdeef4af706ad06'
+    '05e48c33f8205a5359c95f1bd7385c1c1f587e338a514298c07634c0b6c952ba' +
+    '0687d6980502a5d7fa84ef6fdc00104db22c43c7fb83e88ca84f19faa9ee3de1'
 )
 
 # Mock withdrawal params.
@@ -36,3 +36,11 @@ class TestWithdrawal():
     def test_verify_signature(self):
         withdrawal = SignableWithdrawal(**WITHDRAWAL_PARAMS)
         assert withdrawal.verify_signature(MOCK_SIGNATURE, MOCK_PUBLIC_KEY)
+
+    def test_starkware_representation(self):
+        withdrawal = SignableWithdrawal(**WITHDRAWAL_PARAMS)
+        starkware_withdrawal = withdrawal.to_starkware()
+        assert starkware_withdrawal.quantums_amount == 49478023
+
+        # Order expiration should be rounded up and should have a buffer added.
+        assert starkware_withdrawal.expiration_epoch_hours == 444533


### PR DESCRIPTION
(Compare with https://github.com/dydxprotocol/starkex-lib/pull/34)

* Add a buffer to order signatures since orders may have a short time-to-live on the orderbook, but we need to ensure their signatures are valid by the time they reach the blockchain.
  * We don't add a buffer to other signatures since we can enforce at the API level that those have a sufficiently long expiration.
* The signed expiration timestamp should be measured in hours, not seconds, and should be rounded up (except for oracle prices, where expirations are in seconds and rounded down).