### PR TITLE
v0.8.3 Automatically derive default API creds when creating the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ response = web3_client.onboarding.create_user(
     stark_public_key='...',
     ethereum_address='...',
 )
-client.api_key_credentials = response['apiKey']
 web3_client.api_keys.create_api_key(
     ethereum_address='...',
 )
@@ -92,7 +91,6 @@ web3_client_with_keys = Client(
     eth_private_key='...',
 )
 response = web3_client_with_keys.onboarding.create_user()
-client.api_key_credentials = response['apiKey']
 web3_client_with_keys.api_keys.create_api_key(
 )
 ```

--- a/dydx3/dydx_client.py
+++ b/dydx3/dydx_client.py
@@ -89,6 +89,21 @@ class Client(object):
             self.stark_public_key = stark_public_key
             self.stark_public_key_y_coordinate = stark_public_key_y_coordinate
 
+        # Generate default API key credentials if needed and possible.
+        if self.eth_signer and not self.api_key_credentials:
+            # This may involve a web3 call, so recover on failure.
+            try:
+                self.api_key_credentials = (
+                    self.onboarding.recover_default_api_key_credentials(
+                        ethereum_address=self.eth_signer.address,
+                    )
+                )
+            except Exception as e:
+                print(
+                    'Warning: Failed to derive default API key credentials:',
+                    e,
+                )
+
     @property
     def public(self):
         '''

--- a/dydx3/modules/onboarding.py
+++ b/dydx3/modules/onboarding.py
@@ -5,7 +5,6 @@ from web3 import Web3
 from dydx3.constants import OFF_CHAIN_ONBOARDING_ACTION
 from dydx3.constants import OFF_CHAIN_KEY_DERIVATION_ACTION
 from dydx3.eth_signing import SignOnboardingAction
-from dydx3.eth_signing.util import strip_hex_prefix
 from dydx3.helpers.requests import request
 
 

--- a/integration_tests/test_auth_levels.py
+++ b/integration_tests/test_auth_levels.py
@@ -39,7 +39,7 @@ class TestAuthLevels():
         )
 
         # Onboard the user.
-        res = Client(
+        Client(
             host=HOST,
             network_id=NETWORK_ID,
             eth_private_key=eth_account.key,
@@ -92,7 +92,7 @@ class TestAuthLevels():
         )
 
         # Onboard the user.
-        res = Client(
+        Client(
             host=HOST,
             network_id=NETWORK_ID,
             eth_private_key=eth_account.key,
@@ -160,7 +160,7 @@ class TestAuthLevels():
         )
 
         # Onboard the user.
-        res = client.onboarding.create_user()
+        client.onboarding.create_user()
 
         # Register and then revoke a second API key.
         client.api_keys.create_api_key()
@@ -201,7 +201,7 @@ class TestAuthLevels():
             pass
 
         # Register and then revoke a second API key.
-        res = client.api_keys.create_api_key(
+        client.api_keys.create_api_key(
             ethereum_address=ethereum_address,
         )
         client.private.get_api_keys()
@@ -242,7 +242,7 @@ class TestAuthLevels():
             pass
 
         # Register and then revoke a second API key.
-        res = client.api_keys.create_api_key()
+        client.api_keys.create_api_key()
         client.private.get_api_keys()
         client.api_keys.delete_api_key(
             api_key=client.api_key_credentials['key'],

--- a/integration_tests/test_auth_levels.py
+++ b/integration_tests/test_auth_levels.py
@@ -54,7 +54,6 @@ class TestAuthLevels():
             network_id=NETWORK_ID,
             stark_private_key=stark_private_key,
         )
-        client.api_key_credentials = res['apiKey']
 
         # Get the primary account.
         get_account_result = client.private.get_account(
@@ -107,7 +106,6 @@ class TestAuthLevels():
             host=HOST,
             network_id=NETWORK_ID,
         )
-        client.api_key_credentials = res['apiKey']
 
         # Get the primary account.
         get_account_result = client.private.get_account(
@@ -163,7 +161,6 @@ class TestAuthLevels():
 
         # Onboard the user.
         res = client.onboarding.create_user()
-        client.api_key_credentials = res['apiKey']
 
         # Register and then revoke a second API key.
         client.api_keys.create_api_key()
@@ -207,7 +204,6 @@ class TestAuthLevels():
         res = client.api_keys.create_api_key(
             ethereum_address=ethereum_address,
         )
-        client.api_key_credentials = res['apiKey']
         client.private.get_api_keys()
         client.api_keys.delete_api_key(
             api_key=client.api_key_credentials['key'],
@@ -247,7 +243,6 @@ class TestAuthLevels():
 
         # Register and then revoke a second API key.
         res = client.api_keys.create_api_key()
-        client.api_key_credentials = res['apiKey']
         client.private.get_api_keys()
         client.api_keys.delete_api_key(
             api_key=client.api_key_credentials['key'],

--- a/integration_tests/test_integration.py
+++ b/integration_tests/test_integration.py
@@ -49,7 +49,6 @@ class TestIntegration():
 
         # Onboard the user.
         res = client.onboarding.create_user()
-        client.api_key_credentials = res['apiKey']
 
         # Register a new API key.
         client.api_keys.create_api_key()
@@ -150,7 +149,6 @@ class TestIntegration():
         # Onboard the user.
         res = client.onboarding.create_user()
         api_key_credentials = res['apiKey']
-        client.api_key_credentials = api_key_credentials
 
         print('eth_private_key', eth_private_key)
         print('stark_private_key', stark_private_key)

--- a/integration_tests/test_integration.py
+++ b/integration_tests/test_integration.py
@@ -48,7 +48,7 @@ class TestIntegration():
         )
 
         # Onboard the user.
-        res = client.onboarding.create_user()
+        client.onboarding.create_user()
 
         # Register a new API key.
         client.api_keys.create_api_key()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='0.8.2',
+    version='0.8.3',
     packages=find_packages(),
     package_data={
         'dydx3': [

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -18,3 +18,21 @@ class TestOnboarding():
         assert stark_private_key == (
             '0x1bb0389af265c56844fa79b1e586b36f535fee293f59768fdb61d3f280f05fb'
         )
+
+    def test_recover_default_api_key_credentials(self):
+        web3 = Web3()  # Connect to a local Ethereum node.
+        client = Client(
+            host=DEFAULT_HOST,
+            web3=web3,
+        )
+        signer_address = web3.eth.accounts[0]
+        api_key_credentials = (
+            client.onboarding.recover_default_api_key_credentials(
+                signer_address,
+            )
+        )
+        assert api_key_credentials == {
+            'key': 'd850d87e-605e-1f54-17f5-776b72d28319',
+            'secret': 'FJyj-Kf-nbxrUyTCA0pOWICqXNs0PPLYHW5HMXQj',
+            'passphrase': 'Inr0Hj9NymLEcwiMK1dv',
+        }


### PR DESCRIPTION
When using a client with access to an ethereum key (e.g. via web3) and using the default API creds for private endpoints:
* `client.api_key_credentials` no longer needs to be set manually
* API creds never have to be stored by the user