### PR TITLE
v0.9.2 Fix edge case for expiry near start of hour

### DIFF
--- a/dydx3/helpers/request_helpers.py
+++ b/dydx3/helpers/request_helpers.py
@@ -1,7 +1,8 @@
-import json
-import random
-import math
 from datetime import datetime
+import json
+import math
+import random
+
 import dateutil.parser as dp
 
 
@@ -35,7 +36,7 @@ def generate_now_iso():
 
 
 def iso_to_epoch_seconds(iso):
-    return math.floor(dp.parse(iso).timestamp())
+    return dp.parse(iso).timestamp()
 
 
 def epoch_seconds_to_iso(epoch):

--- a/dydx3/helpers/request_helpers.py
+++ b/dydx3/helpers/request_helpers.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import json
-import math
 import random
 
 import dateutil.parser as dp

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='0.9.1',
+    version='0.9.2',
     packages=find_packages(),
     package_data={
         'dydx3': [

--- a/tests/starkex/test_order.py
+++ b/tests/starkex/test_order.py
@@ -81,3 +81,15 @@ class TestOrder():
         )
         starkware_order = order.to_starkware()
         assert starkware_order.quantums_amount_fee == 50751
+
+    def test_order_expiration_boundary_case(self):
+        order = SignableOrder(
+            **dict(
+                ORDER_PARAMS,
+                expiration_epoch_seconds=iso_to_epoch_seconds(
+                    # Less than one second after the start of the hour.
+                    '2021-02-24T16:00:00.407Z',
+                ),
+            ),
+        )
+        assert order.to_starkware().expiration_epoch_hours == 448553


### PR DESCRIPTION
The `private.create_order()` function was failing with invalid signatures when the expiration timestamp was less than one second and greater than one millisecond after the hour, e.g. `2021-02-24T16:00:00.407Z`.

This happened because the expiration was sent in the POST body with millisecond precision, but `SignableOrder` was given `expiration_epoch_seconds` with one-second precision. Since the expiration is rounded up to the nearest hour before being signed, this resulted in a mismatch between the parameters being signed, and the parameters against which the signature was validated on the backend.