### PR TITLE
v1.0.6: fix unexpected value cannot become int [BAC-1189]

### DIFF
--- a/dydx3/helpers/request_helpers.py
+++ b/dydx3/helpers/request_helpers.py
@@ -25,7 +25,7 @@ def json_stringify(data):
 def random_client_id():
     # TODO: Backend should treat client ID as a string, not a number.
     # NOTE: For now, need to make sure to remove leading zeros.
-    return str(int(str(random.random())[2:]))
+    return str(int(float(str(random.random())[2:])))
 
 
 def generate_now_iso():

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='1.0.5',
+    version='1.0.6',
     packages=find_packages(),
     package_data={
         'dydx3': [


### PR DESCRIPTION
- error: Hi dydx team, just fyi I'm occasionally getting an error from create_order function in the dydx python client:

  File "/home/william/.local/lib/python3.8/site-packages/dydx3/modules/private.py", line 468, in create_order
    client_id = client_id or random_client_id()
  File "/home/william/.local/lib/python3.8/site-packages/dydx3/helpers/request_helpers.py", line 28, in random_client_id
    return str(int(str(random.random())[2:]))
builtins.ValueError: invalid literal for int() with base 10: '898963817720706e-05'

- stackoverflow: https://stackoverflow.com/questions/1841565/valueerror-invalid-literal-for-int-with-base-10

- I couldn't replicate but I could verify that weird float values did end up looking correct 