### PR TITLE
Remove test dependencies for library install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ REQUIREMENTS = [
     'eth-account>=0.4.0,<0.6.0',
     'mpmath==1.0.0',
     'pytest>=4.4.0,<5.0.0',
-    'requests-mock==1.6.0',
     'requests==2.22.0',
     'setuptools==50.3.2',
     'sympy==1.6',


### PR DESCRIPTION
Pinned pytest version is over a year old and doesn't seem to play nice when using `poetry add dydx-v3-python`