### PR TITLE
v1.4.0 Reformat request responses and return HTTP headers [BAC-2052]

### DIFF
--- a/dydx3/helpers/requests.py
+++ b/dydx3/helpers/requests.py
@@ -14,6 +14,12 @@ session.headers.update({
 })
 
 
+class Response(object):
+    def __init__(self, data={}, headers=None):
+        self.data = data
+        self.headers = headers
+
+
 def request(uri, method, headers=None, data_values={}):
     response = send_request(
         uri,
@@ -25,7 +31,11 @@ def request(uri, method, headers=None, data_values={}):
     )
     if not str(response.status_code).startswith('2'):
         raise DydxApiError(response)
-    return response.json() if response.content else '{}'
+
+    if response.content:
+        return Response(response.json(), response.headers)
+    else:
+        return Response('{}', response.headers)
 
 
 def send_request(uri, method, headers=None, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='1.3.1',
+    version='1.4.0',
     packages=find_packages(),
     package_data={
         'dydx3': [

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -14,51 +14,60 @@ class TestPublic():
 
     def test_check_if_user_exists(self):
         public = Client(API_HOST).public
-        json = public.check_if_user_exists(ADDRESS_1)
-        assert json == {'exists': False}
+        resp = public.check_if_user_exists(ADDRESS_1)
+        assert resp.data == {'exists': False}
+        assert resp.headers != {}
 
     def test_check_if_username_exists(self):
         public = Client(API_HOST).public
-        json = public.check_if_username_exists('foo')
-        assert json == {'exists': False}
+        resp = public.check_if_username_exists('foo')
+        assert resp.data == {'exists': False}
+        assert resp.headers != {}
 
     def test_get_markets(self):
         public = Client(API_HOST).public
-        json = public.get_markets()
-        assert json != {}
+        resp = public.get_markets()
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_orderbook(self):
         public = Client(API_HOST).public
-        json = public.get_orderbook(MARKET_BTC_USD)
-        assert json != {}
+        resp = public.get_orderbook(MARKET_BTC_USD)
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_stats(self):
         public = Client(API_HOST).public
-        json = public.get_stats(
+        resp = public.get_stats(
             MARKET_BTC_USD,
             MARKET_STATISTIC_DAY_ONE,
         )
-        assert json != {}
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_trades(self):
         public = Client(API_HOST).public
-        json = public.get_trades(MARKET_BTC_USD)
-        assert json != {}
+        resp = public.get_trades(MARKET_BTC_USD)
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_historical_funding(self):
         public = Client(API_HOST).public
-        json = public.get_historical_funding(MARKET_BTC_USD)
-        assert json != {}
+        resp = public.get_historical_funding(MARKET_BTC_USD)
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_candles(self):
         public = Client(API_HOST).public
-        json = public.get_candles(MARKET_BTC_USD)
-        assert json != {}
+        resp = public.get_candles(MARKET_BTC_USD)
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_get_fast_withdrawal(self):
         public = Client(API_HOST).public
-        json = public.get_fast_withdrawal()
-        assert json != {}
+        resp = public.get_fast_withdrawal()
+        assert resp.data != {}
+        assert resp.headers != {}
 
     def test_verify_email(self):
         try:
@@ -71,5 +80,6 @@ class TestPublic():
 
     def test_public_retroactive_mining(self):
         public = Client(API_HOST).public
-        json = public.get_public_retroactive_mining_rewards(ADDRESS_1)
-        assert json != {}
+        resp = public.get_public_retroactive_mining_rewards(ADDRESS_1)
+        assert resp.data != {}
+        assert resp.headers != {}


### PR DESCRIPTION
Reformat responses to put the `json` under `resp.data` and `headers` under `resp.headers`

Before:
```
json = client.public.getMarkets()
```

Now:
```
resp = client.public.getMarkets()
json = resp.data
headers = resp.headers
```

This is a breaking change to current integrations and should be addressed before bumping to this version!