### PR TITLE
Empty request body for testnet tokens

### DIFF
--- a/dydx3/modules/private.py
+++ b/dydx3/modules/private.py
@@ -1000,7 +1000,7 @@ class Private(object):
         if (self.network_id != 3):
             raise ValueError('network_id is not Ropsten')
 
-        return self._post('testnet/tokens')
+        return self._post('testnet/tokens', {})
 
     # ============ Signing ============
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='1.4.2',
+    version='1.4.3',
     packages=find_packages(),
     package_data={
         'dydx3': [


### PR DESCRIPTION
Without this fix, using the request_testnet_tokens
function yields the following error for me:

TypeError: _post() missing 1 required positional argument: 'data'