### PR TITLE
v1.4.6 add parameters get_fast_withdrawal

### DIFF
--- a/dydx3/modules/public.py
+++ b/dydx3/modules/public.py
@@ -180,16 +180,37 @@ class Public(object):
             {'effectiveBeforeOrAt': effective_before_or_at},
         )
 
-    def get_fast_withdrawal(self):
+    def get_fast_withdrawal(
+        self,
+        creditAsset=None,
+        creditAmount=None,
+        debitAmount=None,
+    ):
         '''
         Get all fast withdrawal account information
+
+        :param creditAsset: optional
+        :type creditAsset: str
+
+        :param creditAmount: optional
+        :type creditAmount: str
+
+        :param debitAmount: optional
+        :type debitAmount: str
 
         :returns: All fast withdrawal accounts
 
         :raises: DydxAPIError
         '''
         uri = '/v3/fast-withdrawals'
-        return self._get(uri)
+        return self._get(
+            uri,
+            {
+                'creditAsset': creditAsset,
+                'creditAmount': creditAmount,
+                'debitAmount': debitAmount,
+            },
+        )
 
     def get_candles(
         self,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-v3-python',
-    version='1.4.5',
+    version='1.4.6',
     packages=find_packages(),
     package_data={
         'dydx3': [


### PR DESCRIPTION
Missing the parameters of the http request: https://docs.dydx.exchange/#get-fast-withdrawal-liquidity