### PR TITLE
upgrade tox to latest minor version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install --upgrade pip && sudo pip install -r requirements.txt
+          command: sudo pip install -r requirements.txt
       - run:
           name: test
           command: tox
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install --upgrade pip && sudo pip install -r requirements-lint.txt
+          command: sudo pip install -r requirements-lint.txt
       - run:
           name: lint
           command: flake8
@@ -34,7 +34,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install --upgrade pip && sudo pip install -r requirements-publish.txt
+          command: sudo pip install -r requirements-publish.txt
       - run:
           name: init .pypirc
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install -r requirements.txt
+          command: sudo pip install --upgrade pip && sudo pip install -r requirements.txt
       - run:
           name: test
           command: tox
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install -r requirements-lint.txt
+          command: sudo pip install --upgrade pip && sudo pip install -r requirements-lint.txt
       - run:
           name: lint
           command: flake8
@@ -34,7 +34,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip install -r requirements-publish.txt
+          command: sudo pip install --upgrade pip && sudo pip install -r requirements-publish.txt
       - run:
           name: init .pypirc
           command: |

--- a/README.md
+++ b/README.md
@@ -135,9 +135,12 @@ The path should point to a C++ shared library file, built from Starkware's `cryp
 
 ## Running tests
 
+If you want to run tests when developing the library locally, clone the repo and run:
+
 ```
+pip install -r requirements.txt
 docker-compose up # In a separate terminal
 V3_API_HOST=<api-host> tox
 ```
 
-NOTE: `api-host` should be `https://api.stage.dydx.exchange`
+NOTE: `api-host` should be `https://api.stage.dydx.exchange` to test in staging.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ pytest>=4.4.0,<5.0.0
 requests-mock==1.6.0
 requests==2.22.0
 setuptools==50.3.2
-six==1.14
+six==1.12
 sympy==1.6
-tox==3.25.0
+tox==3.13.2
 web3>=5.0.0,<6.0.0
 importlib-metadata>=1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ pytest>=4.4.0,<5.0.0
 requests-mock==1.6.0
 requests==2.22.0
 setuptools==50.3.2
-six==1.12
+six==1.14
 sympy==1.6
-tox==3.13.2
+tox==3.25.0
 web3>=5.0.0,<6.0.0
 importlib-metadata>=1.6.1


### PR DESCRIPTION
#133 broke local installation:

```
INFO: pip is looking at multiple versions of dateparser to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 12) and importlib-metadata>=1.6.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested importlib-metadata>=1.6.1
    tox 3.13.2 depends on importlib-metadata<1 and >=0.12
```

This upgrades `tox` to the latest minor version (v3.25.0), which caused another conflict with `six`:

```
ERROR: Cannot install -r requirements.txt (line 12), -r requirements.txt (line 2), -r requirements.txt (line 7) and six==1.12 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested six==1.12
    ecdsa 0.16.0 depends on six>=1.9.0
    requests-mock 1.6.0 depends on six
    tox 3.25.0 depends on six>=1.14.0
```

So this also upgrades `six` to v1.14.0.