### PR TITLE
Tweak: cause negative sizes to raise `ValueError` with context hint

### DIFF
--- a/dydx3/modules/private.py
+++ b/dydx3/modules/private.py
@@ -545,6 +545,8 @@ class Private(object):
                     'No signature provided and client was not ' +
                     'initialized with stark_private_key'
                 )
+            if float(size) <= 0:
+                raise ValueError(f"Method `create_order` expects a positive size, but received: {size=}")
             order_to_sign = SignableOrder(
                 network_id=self.network_id,
                 position_id=position_id,


### PR DESCRIPTION
This tweak catches negative sizes and raises a `ValueError` with a context tip, instead of raising an `AssertionError` from the cryptography code. This does not change the behavior of the code (besides raising a more specific error type) and is just a hint for dev UX purposes.

### New traceback: `ValueError` with hint from `create_order`
```
Traceback (most recent call last):
  ...
  File "foobar/venv/lib/python3.8/site-packages/dydx3/modules/private.py", line 549, in create_order
    raise ValueError(f"Method `create_order` expects a positive size, but received: {size=}")
ValueError: Method `create_order` expects a positive size, but received: size='-0.1'

```

### Old traceback: `AssertionError` from `pedersen_hash_as_point`
```
Traceback (most recent call last):
  ...
  File "foobar/venv/lib/python3.8/site-packages/dydx3/modules/private.py", line 559, in create_order
    order_signature = order_to_sign.sign(self.stark_private_key)
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/signable.py", line 32, in sign
    r, s = sign(self.hash, int(private_key_hex, 16))
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/signable.py", line 27, in hash
    self._hash = self._calculate_hash()
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/order.py", line 168, in _calculate_hash
    get_hash(
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/starkex_resources/proxy.py", line 39, in get_hash
    return py_pedersen_hash(*elements)
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/starkex_resources/python_signature.py", line 251, in py_pedersen_hash
    return pedersen_hash_as_point(*elements)[0]
  File "foobar/venv/lib/python3.8/site-packages/dydx3/starkex/starkex_resources/python_signature.py", line 261, in pedersen_hash_as_point
    assert 0 <= x < FIELD_PRIME
AssertionError
```
Another option would be to convert the value with `size = str(abs(float(size)))` but I did not want to impact functionality.