### PR TITLE
Update example orders.py to match client response

### DIFF
--- a/examples/orders.py
+++ b/examples/orders.py
@@ -33,7 +33,7 @@ client.stark_private_key = stark_private_key
 
 # Get our position ID.
 account_response = client.private.get_account()
-position_id = account_response['account']['positionId']
+position_id = account_response.data['account']['positionId']
 
 # Post an bid at a price that is unlikely to match.
 order_params = {


### PR DESCRIPTION
`client.private.get_account` returns an instance of `dydx3.helpers.requests.Response`. Therefore, one has to get the response `data` in order to get access to the `account` dict.