### PR TITLE
fix test

### DIFF
--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -64,7 +64,7 @@ class TestPublic():
 
     def test_get_candles(self):
         public = Client(API_HOST).public
-        resp = public.get_candles(MARKET_BTC_USD)
+        resp = public.get_candles(MARKET_BTC_USD, resolution='1HOUR')
         assert resp.data != {}
         assert resp.headers != {}
 


### PR DESCRIPTION
We are using the candles endpoint in the integration tests to fetch all resolutions, which periodically fails. Lets just fetch 1 resolution to make it more consistent