### PR TITLE
Solved Unknown kwargs with 'gasPrice' error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.idea/
 
  # C extensions
 *.so

--- a/dydx3/modules/eth.py
+++ b/dydx3/modules/eth.py
@@ -120,15 +120,7 @@ class Eth(object):
         auto_detect_nonce = 'nonce' not in options
         if auto_detect_nonce:
             options['nonce'] = self.get_next_nonce(options['from'])
-        if 'gasPrice' not in options:
-            try:
-                options['gasPrice'] = (
-                    self.web3.eth.gasPrice + DEFAULT_GAS_PRICE_ADDITION
-                )
-            except Exception:
-                options['gasPrice'] = DEFAULT_GAS_PRICE
-        if 'value' not in options:
-            options['value'] = 0
+
         gas_multiplier = options.pop('gasMultiplier', DEFAULT_GAS_MULTIPLIER)
         if 'gas' not in options:
             try:


### PR DESCRIPTION
https://github.com/dydxprotocol/dydx-v3-python/blob/master/dydx3/modules/eth.py#L123

removed the above line of code  that creates a gasPrice key in the dict options that raises unknown kwargs exceptions while signing the transaction because the gasPrice has been removed from the transaction option for ethereum ,and now it uses maxFeePerGas and maxPriorityFeePerGas instead of gasPrice