### PR TITLE
Sir/python_3114

### DIFF
--- a/dydx3/dydx_client.py
+++ b/dydx3/dydx_client.py
@@ -59,7 +59,7 @@ class Client(object):
                 )
             self.web3 = web3 or Web3(web3_provider)
             self.eth_signer = SignWithWeb3(self.web3)
-            self.default_address = self.web3.eth.defaultAccount or None
+            self.default_address = self.web3.eth.default_account or None
             self.network_id = self.web3.net.version
 
         if eth_private_key is not None or web3_account is not None:

--- a/dydx3/eth_signing/eth_prive_action.py
+++ b/dydx3/eth_signing/eth_prive_action.py
@@ -67,5 +67,5 @@ class SignEthPrivateAction(SignOffChainAction):
                 util.hash_string(timestamp),
             ],
         ]
-        struct_hash = Web3.solidityKeccak(*data)
+        struct_hash = Web3.solidity_keccak(*data)
         return self.get_eip712_hash(struct_hash)

--- a/dydx3/eth_signing/onboarding_action.py
+++ b/dydx3/eth_signing/onboarding_action.py
@@ -82,5 +82,5 @@ class SignOnboardingAction(SignOffChainAction):
             data[0].append('bytes32')
             data[1].append(util.hash_string(ONLY_SIGN_ON_DOMAIN_MAINNET))
 
-        struct_hash = Web3.solidityKeccak(*data)
+        struct_hash = Web3.solidity_keccak(*data)
         return self.get_eip712_hash(struct_hash)

--- a/dydx3/eth_signing/sign_off_chain_action.py
+++ b/dydx3/eth_signing/sign_off_chain_action.py
@@ -85,7 +85,7 @@ class SignOffChainAction(object):
         }
 
     def get_eip712_hash(self, struct_hash):
-        return Web3.solidityKeccak(
+        return Web3.solidity_keccak(
             [
                 'bytes2',
                 'bytes32',
@@ -99,7 +99,7 @@ class SignOffChainAction(object):
         )
 
     def get_domain_hash(self):
-        return Web3.solidityKeccak(
+        return Web3.solidity_keccak(
             [
                 'bytes32',
                 'bytes32',

--- a/dydx3/eth_signing/signers.py
+++ b/dydx3/eth_signing/signers.py
@@ -48,7 +48,7 @@ class SignWithWeb3(Signer):
             raise ValueError(
                 'Must set ethereum_address or web3.eth.defaultAccount',
             )
-        raw_signature = self.web3.eth.signTypedData(
+        raw_signature = self.web3.eth.sign_typed_data(
             signer_address,
             eip712_message,
         )

--- a/dydx3/eth_signing/util.py
+++ b/dydx3/eth_signing/util.py
@@ -28,12 +28,12 @@ def ec_recover_typed_signature(
     if sig_type == constants.SIGNATURE_TYPE_NO_PREPEND:
         prepended_hash = hashVal
     elif sig_type == constants.SIGNATURE_TYPE_DECIMAL:
-        prepended_hash = Web3.solidityKeccak(
+        prepended_hash = Web3.solidity_keccak(
             ['string', 'bytes32'],
             [PREPEND_DEC, hashVal],
         )
     elif sig_type == constants.SIGNATURE_TYPE_HEXADECIMAL:
-        prepended_hash = Web3.solidityKeccak(
+        prepended_hash = Web3.solidity_keccak(
             ['string', 'bytes32'],
             [PREPEND_HEX, hashVal],
         )
@@ -45,7 +45,7 @@ def ec_recover_typed_signature(
 
     signature = typed_signature[:-2]
 
-    address = w3.eth.account.recoverHash(prepended_hash, signature=signature)
+    address = w3.eth.account._recover_hash(prepended_hash, signature=signature)
     return address
 
 
@@ -104,4 +104,4 @@ def addresses_are_equal(
 
 
 def hash_string(input):
-    return Web3.solidityKeccak(['string'], [input])
+    return Web3.solidity_keccak(['string'], [input])

--- a/dydx3/modules/onboarding.py
+++ b/dydx3/modules/onboarding.py
@@ -135,7 +135,7 @@ class Onboarding(object):
             action=OFF_CHAIN_KEY_DERIVATION_ACTION,
         )
         signature_int = int(signature, 16)
-        hashed_signature = Web3.solidityKeccak(['uint256'], [signature_int])
+        hashed_signature = Web3.solidity_keccak(['uint256'], [signature_int])
         private_key_int = int(hashed_signature.hex(), 16) >> 5
         private_key_hex = hex(private_key_int)
         public_x, public_y = private_key_to_public_key_pair_hex(
@@ -163,11 +163,11 @@ class Onboarding(object):
         )
         r_hex = signature[2:66]
         r_int = int(r_hex, 16)
-        hashed_r_bytes = bytes(Web3.solidityKeccak(['uint256'], [r_int]))
+        hashed_r_bytes = bytes(Web3.solidity_keccak(['uint256'], [r_int]))
         secret_bytes = hashed_r_bytes[:30]
         s_hex = signature[66:130]
         s_int = int(s_hex, 16)
-        hashed_s_bytes = bytes(Web3.solidityKeccak(['uint256'], [s_int]))
+        hashed_s_bytes = bytes(Web3.solidity_keccak(['uint256'], [s_int]))
         key_bytes = hashed_s_bytes[:16]
         passphrase_bytes = hashed_s_bytes[16:31]
 

--- a/dydx3/starkex/helpers.py
+++ b/dydx3/starkex/helpers.py
@@ -121,7 +121,7 @@ def get_transfer_erc20_fact(
                 token_decimals,
             )
         )
-    hex_bytes = Web3.solidityKeccak(
+    hex_bytes = Web3.solidity_keccak(
         [
             'address',
             'uint256',

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,11 +3,11 @@ cytoolz==0.12.1
 dateparser==1.0.0
 ecdsa>=0.16.0
 eth_keys
-eth-account>=0.4.0,<0.6.0
+eth-account>=0.4.0,<=0.9.0
 mpmath==1.0.0
 pytest>=7.0.0
 requests>=2.22.0,<3.0.0
 six==1.14
 sympy==1.6
 tox>=4.3.4
-web3>=5.0.0,<6.0.0
+web3>=5.0.0,<=6.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ cytoolz==0.12.1
 dateparser==1.0.0
 ecdsa>=0.16.0
 eth_keys
-eth-account>=0.4.0,<0.6.0
+eth-account>=0.4.0,<=0.9.0
 mpmath==1.0.0
 requests>=2.22.0,<3.0.0
 six==1.14
 sympy==1.6
-web3>=5.0.0,<6.0.0
+web3>=5.0.0,<=6.9.0

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ REQUIREMENTS = [
     'dateparser==1.0.0',
     'ecdsa>=0.16.0',
     'eth_keys',
-    'eth-account>=0.4.0,<0.6.0',
+    'eth-account>=0.4.0,<=0.9.0',
     'mpmath==1.0.0',
     'requests>=2.22.0,<3.0.0',
     'sympy==1.6',
-    'web3>=5.0.0,<6.0.0',
+    'web3>=5.0.0,<=6.9.0',
 ]
 
 setup(
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.11.4',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ exclude = dydx3/starkex/starkex_resources
 per-file-ignores = __init__.py:F401
 
 [tox]
-envlist = python2.7, python3.4, python3.5, python3.6, python3.9, python3.11
+envlist = python2.7, python3.4, python3.5, python3.6, python3.9, python3.11, python3.11.4
 
 [testenv]
 commands =


### PR DESCRIPTION
**This PR solves compatibility issues when using `dydx-v3-python` with `python 3.11.4`**
The issues stem from conflicting imports by the `parsimonious package`, which is used by `eth-abi` package, which in turn is used by both `eth-account` and `web3` packages.

*The following github issues seem related to this PR*:
- https://github.com/dydxprotocol/dydx-v3-python/issues/209
- https://github.com/dydxprotocol/dydx-v3-python/issues/187

**What this PR does**:
- move upper version constraint for the following packages to current versions in both requirements.txt and requirements-test.txt:
    - `eth-account`
    - `web3`

- modify to include new package versions and `python 3.11.4` here:
    - `tox.ini`
    - `setup.py`

- change source code to rename these function calls (see corresponding resources in parentheses): 
	- `solidityKeccak` -> Web3.solidity_keccak (https://web3py.readthedocs.io/en/stable/releases.html#id54)
	- `signTypedData` -> sign_typed_data (https://web3py.readthedocs.io/en/stable/releases.html#id124)
	- `defaultAccount` -> default_account (https://web3py.readthedocs.io/en/stable/releases.html#id129)
	- `recoverHash` -> _recover_hash (https://web3py.readthedocs.io/en/v5/web3.eth.account.html)
